### PR TITLE
Fix simulation with iverilog

### DIFF
--- a/cpu.v
+++ b/cpu.v
@@ -34,9 +34,10 @@ parameter WRITE_BACK = 1 << 4;
 /* fetch */
 assign mem_i_rstrb = 1;
 assign mem_i_addr = pc;
-assign f_insn = mem_i_rdata;
 reg [31:0]  f_addr;
 wire [31:0] f_insn;
+
+assign f_insn = mem_i_rdata;
 
 always @(posedge clk) begin if (f_en) begin
 	$display("fetching pc = %x", pc);


### PR DESCRIPTION
Assigning a wire before declaring it leads to implicit declaration.
This ended up as a double declaration:

cpu.v:39: error: duplicate declaration for net or variable 'f_insn' in 'rv32i'.