### PR TITLE
Prevent spurious branches

### DIFF
--- a/cpu.v
+++ b/cpu.v
@@ -200,6 +200,7 @@ always @(posedge clk) begin if (d_en) begin
 			    `ALU_OR;
 		d_op_val1 <= (funct3_w[1:0] == `CSR_RW) ? 0 : csr_val;
 		d_op_val2 <= (funct3_w[2]) ? rs1_w : reg1_w;
+		d_bcu_op <= `BCU_DISABLE;
 	end else begin
 		d_csr_rd <= 0;
 		d_csr_wr <= 0;


### PR DESCRIPTION
In case a CSR (or any system, actually) instruction was
directly executed after a taken branch, the csr would also
incorrectly branch to somewhere.
Because BCU was still enabled and thus x_taken would still be
possibly set to 1 which would therefore set m_taken to 1 also.

To prevent that, just bare in mind to set d_bcu_op in ALL if branch.

With this commit, csr unit tests are now passing.