### PR TITLE
make: use 'xxd -p' instead of parsing output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ PCF = orangecrab_r0.2.pcf
 	$(OBJCOPY) -j .text -O binary $^ $@ && truncate -s %4 $@ && $(OBJCOPY) -I binary --reverse-bytes=4 $@
 
 %.hex: %.bin
-	xxd -c4 $< | sed 's/[0-9a-fA-F]\+: //; s/ //; s/\(........\).*/\1/' >$@
+	xxd -c4 -p $< >$@
 
 clean:
 	rm -f *.elf *.bin *.hex a.out


### PR DESCRIPTION
The default output of xxd is meant for humans, but the expected format
for .hex inclusion is much simpler.
The output of xxd was thus parsed to strip all human-related formatting,
but it turns out xxd already has an option to do that.

This patch makes use of that option in order to simplify the top
Makefile.